### PR TITLE
Add initial integration for libdfp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ project('Foo')
 
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
-numeric_glib = dependency('numeric-glib-1.0', fallback: ['numeric-glib', 'numeric_glib'])
+numeric_glib = dependency('numeric-glib-1.0', fallback: ['numeric-glib', 'numeric_glib_dep'])
+numeric_glib_vala = dependency('numeric-glib-1.0', fallback: ['numeric-glib', 'numeric_glib_vala_dep'])
 
-executable('foo', dependencies: [glib, gobject, numeric_glib])
+executable('foo', 'foo.c', dependencies: [glib, gobject, numeric_glib])
+executable('foo', 'foo.vala', dependencies: [glib, gobject, numeric_glib_vala])
 ```

--- a/meson.build
+++ b/meson.build
@@ -10,5 +10,3 @@ add_project_arguments(['-D__STDC_WANT_DEC_FP__'], language: 'c')
 
 subdir('src')
 subdir('tests')
-
-executable('test2', 'test.c', dependencies: [dfp])

--- a/meson.build
+++ b/meson.build
@@ -3,8 +3,12 @@ project('Numeric-GLib', 'c', 'vala')
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
 quadmath = meson.get_compiler('c').find_library('quadmath')
+
 dfp = meson.get_compiler('c').find_library('dfp')
+add_project_arguments(['-D', 'HAVE_LIBDFP'], language: 'vala')
+add_project_arguments(['-D__STDC_WANT_DEC_FP__'], language: 'c')
 
 subdir('src')
 subdir('tests')
 
+executable('test2', 'test.c', dependencies: [dfp])

--- a/meson.build
+++ b/meson.build
@@ -4,9 +4,13 @@ glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
 quadmath = meson.get_compiler('c').find_library('quadmath')
 
-dfp = meson.get_compiler('c').find_library('dfp')
-add_project_arguments(['-D', 'HAVE_LIBDFP'], language: 'vala')
-add_project_arguments(['-D__STDC_WANT_DEC_FP__'], language: 'c')
+if get_option('with_libdfp')
+    dfp = meson.get_compiler('c').find_library('dfp')
+    add_project_arguments(['-D', 'HAVE_LIBDFP'], language: 'vala')
+    add_project_arguments(['-D__STDC_WANT_DEC_FP__'], language: 'c')
+else
+    dfp = []
+endif
 
 subdir('src')
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('Numeric-GLib', 'c', 'vala')
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
 quadmath = meson.get_compiler('c').find_library('quadmath')
+dfp = meson.get_compiler('c').find_library('dfp')
 
 subdir('src')
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ quadmath = meson.get_compiler('c').find_library('quadmath')
 if get_option('with_libdfp')
     dfp = meson.get_compiler('c').find_library('dfp')
     add_project_arguments(['-D', 'HAVE_LIBDFP'], language: 'vala')
-    add_project_arguments(['-D__STDC_WANT_DEC_FP__'], language: 'c')
+    add_project_arguments(['-DHAVE_LIBDFP', '-D__STDC_WANT_DEC_FP__'], language: 'c')
 else
     dfp = []
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('with_libdfp', type: 'boolean', value: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,7 @@ numeric_sources = [
     'numeric-types.c',
     'numeric-vector.c']
 numeric_glib_lib = library('numeric-glib-1.0', numeric_sources,
-                           dependencies: [glib, gobject],
+                           dependencies: [glib, gobject, dfp],
                            c_args: '-DNUMERIC_COMPILATION',
                            install: true)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,9 +8,11 @@ numeric_glib_lib = library('numeric-glib-1.0', numeric_sources,
                            c_args: '-DNUMERIC_COMPILATION',
                            install: true)
 
-numeric_glib = declare_dependency(link_with: numeric_glib_lib,
-                                  include_directories: include_directories('.'),
-                                  sources: 'numeric-glib-1.0.vapi')
+numeric_glib_dep = declare_dependency(link_with: numeric_glib_lib,
+                                    include_directories: include_directories('.'))
+
+numeric_glib_vala_dep = declare_dependency(dependencies: numeric_glib_dep,
+                                           sources: 'numeric-glib-1.0.vapi')
 
 install_headers(['numeric.h', 'numeric-types.h', 'numeric-vector.h'], subdir: 'numeric-glib-1.0')
 install_data('numeric-glib-1.0.vapi', install_dir: 'share/vala/vapi')

--- a/src/numeric-glib-1.0.vapi
+++ b/src/numeric-glib-1.0.vapi
@@ -123,19 +123,9 @@ namespace Numeric
 		[CCode (cname = "strtod128", cheader_filename="dfp/stdlib.h")]
 		public static decimal128 parse (string s, out char sp = null);
 
-		[CCode (cname = "snprintf", cheader_filename = "stdio.h")]
-		private static int _snprintf (char[] s, string format, ...);
-
 		public string to_string ()
 		{
-			var buffer = new char[128];
-			var format = "%DDf";
-			var n = _snprintf (buffer, format, this);
-			if (n >= buffer.length) {
-				buffer = new char[n + 1];
-				_snprintf (buffer, format, this);
-			}
-			return (string) buffer;
+			return "%DDf".printf (this);
 		}
 	}
 

--- a/src/numeric-glib-1.0.vapi
+++ b/src/numeric-glib-1.0.vapi
@@ -92,7 +92,6 @@ namespace Numeric
 				_quadmath_snprintf (buffer, format, this);
 			}
 			return (string) buffer;
-
 		}
 	}
 
@@ -123,9 +122,20 @@ namespace Numeric
 	{
 		[CCode (cname = "strtod128", cheader_filename="dfp/stdlib.h")]
 		public static decimal128 parse (string s, out char sp = null);
+
+		[CCode (cname = "snprintf", cheader_filename = "stdio.h")]
+		private static int _snprintf (char[] s, string format, ...);
+
 		public string to_string ()
 		{
-			return "%DDf".printf (this);
+			var buffer = new char[128];
+			var format = "%DDf";
+			var n = _snprintf (buffer, format, this);
+			if (n >= buffer.length) {
+				buffer = new char[n + 1];
+				_snprintf (buffer, format, this);
+			}
+			return (string) buffer;
 		}
 	}
 

--- a/src/numeric-glib-1.0.vapi
+++ b/src/numeric-glib-1.0.vapi
@@ -97,13 +97,37 @@ namespace Numeric
 	}
 
 	[FloatingType (rank = 6)]
-	public struct decimal32 {}
+	public struct decimal32
+	{
+		[CCode (cname = "strtod32", cheader_filename="dfp/stdlib.h")]
+		public static decimal32 parse (string s, out char sp = null);
+		public string to_string ()
+		{
+			return "%Hf".printf (this);
+		}
+	}
 
 	[FloatingType (rank = 10)]
-	public struct decimal64 {}
+	public struct decimal64
+	{
+		[CCode (cname = "strtod64", cheader_filename="dfp/stdlib.h")]
+		public static decimal64 parse (string s, out char sp = null);
+		public string to_string ()
+		{
+			return "%Df".printf (this);
+		}
+	}
 
 	[FloatingType (rank = 12)]
-	public struct decimal128 {}
+	public struct decimal128
+	{
+		[CCode (cname = "strtod128", cheader_filename="dfp/stdlib.h")]
+		public static decimal128 parse (string s, out char sp = null);
+		public string to_string ()
+		{
+			return "%DDf".printf (this);
+		}
+	}
 
 	[FloatingType (rank = 6)]
 	public struct complex {}

--- a/src/numeric-types.c
+++ b/src/numeric-types.c
@@ -95,3 +95,14 @@ DEFINE_NUMERIC_WITH_BYTESWAP (float_le,  float,  gint32,  GINT32,  LE)
 DEFINE_NUMERIC_WITH_BYTESWAP (float_be,  float,  gint32,  GINT32,  BE)
 DEFINE_NUMERIC_WITH_BYTESWAP (double_le, double, gint32,  GINT64,  LE)
 DEFINE_NUMERIC_WITH_BYTESWAP (double_be, double, gint32,  GINT64,  BE)
+
+#if HAVE_LIBDFP
+extern void register_printf_dfp (void);
+
+__attribute__ ((constructor))
+static void
+numeric_types_init (void)
+{
+    register_printf_dfp ();
+}
+#endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,4 @@
-posix = meson.get_compiler('vala').find_library('posix')
 test('numeric', executable('numeric-test', 'numeric-test.vala',
-                           dependencies: [posix, glib, gobject, numeric_glib, quadmath, dfp]))
+                           dependencies: [glib, gobject, numeric_glib_vala_dep, quadmath, dfp]))
+test('numeric-c', executable('numeric-c-test', 'numeric-c-test.c',
+                           dependencies: [glib, gobject, numeric_glib_dep, quadmath, dfp]))

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,2 +1,3 @@
+posix = meson.get_compiler('vala').find_library('posix')
 test('numeric', executable('numeric-test', 'numeric-test.vala',
-                           dependencies: [glib, gobject, numeric_glib, quadmath]))
+                           dependencies: [posix, glib, gobject, numeric_glib, quadmath, dfp]))

--- a/tests/numeric-c-test.c
+++ b/tests/numeric-c-test.c
@@ -1,0 +1,53 @@
+/* Copyright 2016 Guillaume Poirier-Morency <guillaumepoiriermorency@gmail.com>
+ *
+ * This file is part of Numeric-GLib.
+ *
+ * Numeric-GLib is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Numeric-GLib is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Numeric-GLib.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <dfp/stdlib.h>
+#include <dfp/math.h>
+#include <glib.h>
+
+#include <numeric.h>
+
+void
+test_decimal128 (void)
+{
+    numeric_decimal128 a;
+
+    a = strtod128 ("0.1", NULL);
+
+    g_assert (a == 0.1DL);
+    g_assert_cmpfloat (a + a, ==, 0.2DL);
+    g_assert_cmpfloat (fabsd128 (a), ==, 0.1DL);
+
+    char buffer[128];
+    snprintf (buffer, sizeof buffer, "%DDf", a);
+
+    g_assert_cmpstr (buffer, ==, "0.100000");
+}
+
+int
+main (int argc, char **argv)
+{
+    g_test_init (&argc, &argv, NULL);
+
+    g_test_add_func ("/decimal128", test_decimal128);
+
+    return g_test_run ();
+}

--- a/tests/numeric-c-test.c
+++ b/tests/numeric-c-test.c
@@ -19,9 +19,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <glib.h>
+
+#if HAVE_LIBDFP
 #include <dfp/stdlib.h>
 #include <dfp/math.h>
-#include <glib.h>
+#endif
 
 #include <numeric.h>
 
@@ -30,16 +33,22 @@ test_decimal128 (void)
 {
     numeric_decimal128 a;
 
+#if HAVE_LIBDFP
     a = strtod128 ("0.1", NULL);
+#else
+    a = 0.1DL;
+#endif
 
     g_assert (a == 0.1DL);
     g_assert_cmpfloat (a + a, ==, 0.2DL);
-    g_assert_cmpfloat (fabsd128 (a), ==, 0.1DL);
 
+#if HAVE_LIBDFP
     char buffer[128];
     snprintf (buffer, sizeof buffer, "%DDf", a);
-
     g_assert_cmpstr (buffer, ==, "0.100000");
+
+    g_assert_cmpfloat (fabsd128 (a), ==, 0.1DL);
+#endif
 }
 
 int

--- a/tests/numeric-c-test.c
+++ b/tests/numeric-c-test.c
@@ -43,8 +43,7 @@ test_decimal128 (void)
     g_assert_cmpfloat (a + a, ==, 0.2DL);
 
 #if HAVE_LIBDFP
-    char buffer[128];
-    snprintf (buffer, sizeof buffer, "%DDf", a);
+    g_autofree gchar *buffer = g_strdup_printf ("%DDf", a);
     g_assert_cmpstr (buffer, ==, "0.100000");
 
     g_assert_cmpfloat (fabsd128 (a), ==, 0.1DL);

--- a/tests/numeric-test.vala
+++ b/tests/numeric-test.vala
@@ -126,6 +126,7 @@ public int main (string[] args)
 		assert (4 == y[3]);
 	});
 
+#if HAVE_LIBDFP
 	Test.add_func ("/decimal", () => {
 		var a = decimal128.parse ("0.1");
 		var b = decimal128.parse ("0.1");
@@ -139,6 +140,7 @@ public int main (string[] args)
 		assert (a.to_string () == "0.100000");
 		assert (expected.to_string () == "0.000000");
 	});
+#endif
 
 	return Test.run ();
 }

--- a/tests/numeric-test.vala
+++ b/tests/numeric-test.vala
@@ -50,7 +50,6 @@ public int main (string[] args)
 
 		var c = Value (typeof (float));
 		assert (b.transform (ref c));
-		message ("%f", c.get_float ());
 		assert (a.get_float () == c.get_float ());
 
 		var d = float_be.from_float (5.0f);
@@ -136,6 +135,9 @@ public int main (string[] args)
 		var expected = decimal128.parse ("0.0");
 
 		assert (a + b + c + d  ==  expected);
+
+		assert (a.to_string () == "0.100000");
+		assert (expected.to_string () == "0.000000");
 	});
 
 	return Test.run ();

--- a/tests/numeric-test.vala
+++ b/tests/numeric-test.vala
@@ -128,16 +128,12 @@ public int main (string[] args)
 	});
 
 	Test.add_func ("/decimal", () => {
-		var a = decimal32.parse ("0.1");
-		var b = decimal32.parse ("0.1");
-		var c = decimal32.parse ("0.1");
-		var d = decimal32.parse ("-0.3");
+		var a = decimal128.parse ("0.1");
+		var b = decimal128.parse ("0.1");
+		var c = decimal128.parse ("0.1");
+		var d = decimal128.parse ("-0.3");
 
 		var expected = decimal128.parse ("0.0");
-
-		print (a.to_string ());
-		assert (a.to_string () == "0.1");
-		assert (c.to_string () == "-0.3");
 
 		assert (a + b + c + d  ==  expected);
 	});

--- a/tests/numeric-test.vala
+++ b/tests/numeric-test.vala
@@ -127,7 +127,35 @@ public int main (string[] args)
 	});
 
 #if HAVE_LIBDFP
-	Test.add_func ("/decimal", () => {
+	Test.add_func ("/decimal32", () => {
+		var a = decimal32.parse ("0.1");
+		var b = decimal32.parse ("0.1");
+		var c = decimal32.parse ("0.1");
+		var d = decimal32.parse ("-0.3");
+
+		var expected = decimal32.parse ("0.0");
+
+		assert (a + b + c + d  ==  expected);
+
+		assert (a.to_string () == "0.100000");
+		assert (expected.to_string () == "0.000000");
+	});
+
+	Test.add_func ("/decimal64", () => {
+		var a = decimal64.parse ("0.1");
+		var b = decimal64.parse ("0.1");
+		var c = decimal64.parse ("0.1");
+		var d = decimal64.parse ("-0.3");
+
+		var expected = decimal64.parse ("0.0");
+
+		assert (a + b + c + d  ==  expected);
+
+		assert (a.to_string () == "0.100000");
+		assert (expected.to_string () == "0.000000");
+	});
+
+	Test.add_func ("/decimal128", () => {
 		var a = decimal128.parse ("0.1");
 		var b = decimal128.parse ("0.1");
 		var c = decimal128.parse ("0.1");

--- a/tests/numeric-test.vala
+++ b/tests/numeric-test.vala
@@ -127,5 +127,20 @@ public int main (string[] args)
 		assert (4 == y[3]);
 	});
 
+	Test.add_func ("/decimal", () => {
+		var a = decimal32.parse ("0.1");
+		var b = decimal32.parse ("0.1");
+		var c = decimal32.parse ("0.1");
+		var d = decimal32.parse ("-0.3");
+
+		var expected = decimal128.parse ("0.0");
+
+		print (a.to_string ());
+		assert (a.to_string () == "0.1");
+		assert (c.to_string () == "-0.3");
+
+		assert (a + b + c + d  ==  expected);
+	});
+
 	return Test.run ();
 }


### PR DESCRIPTION
 - [x] make it optional at configure time since libdfp is not commonly packaged (add `-Dwith_libdfp`)
 - [ ] add math operations under the Numeric.Math namespace
 - [ ] add range constants and more under Numeric.decimal[32|64|128]
 - [ ] add tests for GValue boxing/unboxing
 - [ ] add tests for cross-compiling to native targets supporting decimal floats